### PR TITLE
Migrates to GitHub Container Registry

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -12,27 +12,6 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  build-db:
-    if: contains( github.ref, 'master')
-    runs-on: ubuntu-latest
-    steps:
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      -
-        name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push DB
-        uses: docker/build-push-action@v3
-        with:
-          context: "{{defaultContext}}:db"
-          push: true
-          tags: marekvigas/sbb-leto-db:${{ github.ref_name }}
-
   build-api:
     if: contains( github.ref, 'master')
     runs-on: ubuntu-latest
@@ -41,20 +20,21 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       -
-        name: Login to DockerHub
+        name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push API
         uses: docker/build-push-action@v3
         with:
           context: "{{defaultContext}}:src/go-api"
           push: true
-          tags: marekvigas/sbb-leto-api:${{ github.ref_name }}
+          tags: ghcr.io/${{ github.repository_owner }}/api:${{ github.ref_name }}
 
-  build-fe-sbb:
+  build-fe:
     if: contains( github.ref, 'master')
     runs-on: ubuntu-latest
     steps:
@@ -62,23 +42,24 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       -
-        name: Login to DockerHub
+        name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push FE
         uses: docker/build-push-action@v3
         with:
           context: "{{defaultContext}}:fe"
           push: true
-          tags: marekvigas/sbb-leto-form:sbb
+          tags: ghcr.io/${{ github.repository_owner }}/form:${{ github.ref_name }}
           build-args: |
             VITE_API_HOST=https://leto-api.salezko.sk
             VITE_RESULT_REDIRECT=https://sbb.sk/leto
 
-  build-admin-sbb:
+  build-admin:
     if: contains( github.ref, 'master')
     runs-on: ubuntu-latest
     steps:
@@ -86,18 +67,19 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       -
-        name: Login to DockerHub
+        name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push FE
         uses: docker/build-push-action@v3
         with:
           context: "{{defaultContext}}:admin"
           push: true
-          tags: marekvigas/sbb-leto-admin:sbb
+          tags: ghcr.io/${{ github.repository_owner }}/admin:${{ github.ref_name }}
           build-args: |
             REACT_APP_API_HOST=https://leto-api.salezko.sk
 
@@ -109,18 +91,19 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       -
-        name: Login to DockerHub
+        name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push Payments
         uses: docker/build-push-action@v3
         with:
           context: "{{defaultContext}}:payments"
           push: true
-          tags: marekvigas/sbb-leto-payments:${{ github.ref_name }}
+          tags: ghcr.io/${{ github.repository_owner }}/payments:${{ github.ref_name }}
 
   be-unit-test:
     # The type of runner that the job will run on


### PR DESCRIPTION
Updates the workflow to use GitHub Container Registry (ghcr.io) for storing and distributing Docker images. This change involves:

- Removing the Docker Hub configuration.
- Configuring login to ghcr.io using GitHub Actions' secrets.
- Adjusting image tags to use the ghcr.io registry path.
- Updates job names for clarity.