### PR TITLE
Configures pgAdmin with environment variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
 
   pgadmin:
     image: dpage/pgadmin4
+    env_file: pgadmin.env
     networks:
       - cloudflared
       - backend


### PR DESCRIPTION
Enables environment variable configuration for pgAdmin by adding the `env_file` directive in the docker-compose.yml file. This allows for easier and more secure configuration of pgAdmin settings.