### PR TITLE
feat: New reg APIs

### DIFF
--- a/src/go-api/internal/api/api.go
+++ b/src/go-api/internal/api/api.go
@@ -94,7 +94,9 @@ func New(
 	api.GET("/registrations/:id", a.FindRegistrationByID, requireAuth)
 	api.DELETE("/registrations/:id", a.DeleteRegistrationByID, requireAuth)
 	api.PUT("/registrations/:id", a.UpdateRegistration, requireAuth)
+	api.POST("/registrations/:id/resend_confirmation", a.ResendConfirmation, requireAuth)
 	api.POST("/send_payment_notifications", a.SendPaymentNotification, requireAuth)
+	api.POST("/send_payment_reminder", a.SendPaymentReminder, requireAuth)
 
 	return a
 }

--- a/src/go-api/internal/api/registration.go
+++ b/src/go-api/internal/api/registration.go
@@ -125,8 +125,42 @@ func (api *API) UpdateRegistration(c echo.Context) error {
 	return c.JSON(http.StatusAccepted, nil)
 }
 
+func (api *API) ResendConfirmation(c echo.Context) error {
+	regID, err := api.getIntParam(c, "id")
+	if err != nil {
+		return err
+	}
+
+	var req resources.ResendConfirmationRequest
+	if err := c.Bind(&req); err != nil {
+		return err
+	}
+	if errs := validateStruct(&req); errs != nil {
+		return c.JSON(http.StatusUnprocessableEntity, echo.Map{"errors": errs})
+	}
+
+	if err := api.registrationManager.ResendConfirmation(c.Request().Context(), regID, req.Email); err != nil {
+		return api.handleError(err)
+	}
+	return c.JSON(http.StatusAccepted, nil)
+
+}
+
 func (api *API) SendPaymentNotification(c echo.Context) error {
 	resp, err := api.registrationManager.SendPaymentNotifications(c.Request().Context())
+	if err != nil {
+		return api.handleError(err)
+	}
+	return c.JSON(http.StatusOK, resp)
+}
+
+func (api *API) SendPaymentReminder(c echo.Context) error {
+	var req resources.PaymentReminderRequest
+	if err := c.Bind(&req); err != nil {
+		return err
+	}
+
+	resp, err := api.registrationManager.SendPaymentReminder(c.Request().Context(), req.EventId)
 	if err != nil {
 		return api.handleError(err)
 	}

--- a/src/go-api/internal/api/stats_test.go
+++ b/src/go-api/internal/api/stats_test.go
@@ -31,22 +31,7 @@ func (s *StatsSuite) TestGetStat_OK() {
 	})
 	s.Require().NoError(err)
 
-	reg := s.createRegistration()
-
-	_, err = s.db.Exec(`INSERT INTO signups(
-		day_id,
-		registration_id,
-		state,
-		created_at,
-		updated_at
-	) VALUES (
-		$1,
-		$2,
-		'sadf',
-		NOW(),
-		NOW()
-	)`, dayTwo.ID, reg.ID)
-	s.Require().NoError(err)
+	_ = s.createRegistration(dayTwo.ID)
 
 	u := fmt.Sprintf("/api/stats/%d", event.ID)
 	req, rec := s.NewRequest(http.MethodGet, u, nil)

--- a/src/go-api/internal/resources/register.go
+++ b/src/go-api/internal/resources/register.go
@@ -58,3 +58,16 @@ type PaymentNotificationResponse struct {
 	Sent        int  `json:"sent"`
 	FinishedAll bool `json:"finished_all"`
 }
+
+type PaymentReminderRequest struct {
+	EventId int `json:"event_id"`
+}
+
+type PaymentReminderResponse struct {
+	Sent        int  `json:"sent"`
+	FinishedAll bool `json:"finished_all"`
+}
+
+type ResendConfirmationRequest struct {
+	Email string `json:"email"   validate:"email,required"`
+}

--- a/src/go-api/internal/services/mailer/mailgun.go
+++ b/src/go-api/internal/services/mailer/mailgun.go
@@ -18,10 +18,12 @@ import (
 type Client struct {
 	mailgun *mailgun.MailgunImpl
 
-	confirmation *template.Template
-	promo        *template.Template
-	notification *template.Template
-	sender       string
+	confirmation    *template.Template
+	promo           *template.Template
+	notification    *template.Template
+	paymentReminder *template.Template
+
+	sender string
 }
 
 func NewClient(cfg *config.Mailer) (*Client, error) {
@@ -88,6 +90,19 @@ func (c *Client) NotificationMail(ctx context.Context, req *templates.Notificati
 	}
 
 	return c.send(ctx, fmt.Sprintf("Prijatie platby za %s", req.EventName), b.String(),
+		fmt.Sprintf("<%s>", req.Mail))
+}
+
+func (c *Client) PaymentReminderMail(ctx context.Context, req *templates.PaymentReminderReq) error {
+	if c.paymentReminder == nil {
+		return errors.New("payment reminder template not set")
+	}
+	var b bytes.Buffer
+	if err := c.paymentReminder.Execute(&b, req); err != nil {
+		return errors.WithStack(err)
+	}
+
+	return c.send(ctx, fmt.Sprintf("Neevediujeme uhradu za %s", req.EventName), b.String(),
 		fmt.Sprintf("<%s>", req.Mail))
 }
 

--- a/src/go-api/internal/services/mailer/templates/reminder.go
+++ b/src/go-api/internal/services/mailer/templates/reminder.go
@@ -1,0 +1,12 @@
+package templates
+
+type PaymentReminderReq struct {
+	Mail          string
+	ParentName    string
+	ParentSurname string
+	EventName     string
+	Name          string
+	Surname       string
+	Sum           int
+	Payment       PaymentDetails
+}


### PR DESCRIPTION
New APIs added:
- resend confirmation email for an existing registration with an option to change email
- send payment reminder email for a specified event